### PR TITLE
Fix hostname as socket ambiguity

### DIFF
--- a/lib/paracusia/mpd_client.ex
+++ b/lib/paracusia/mpd_client.ex
@@ -149,13 +149,15 @@ defmodule Paracusia.MpdClient do
         _ -> {hostname, port}
       end
 
+    target_description = "#{ip_string(addr_family, hostname)}:#{port_conn} (#{addr_family})"
+
     case :gen_tcp.connect(hostname_conn, port_conn, opts) do
       {:ok, sock} ->
-        _ = Logger.debug("Successfully connected to #{ip_string(addr_family, hostname)}")
+        _ = Logger.debug("Successfully connected to #{target_description}")
         sock
 
       {:error, :econnrefused} when next_addr_idx == 0 ->
-        _ = Logger.error("Connection refused, retry after #{retry_after} ms.")
+        _ = Logger.error("Connection to #{target_description} refused, retry after #{retry_after} ms.")
         :timer.sleep(retry_after)
         connect_retry(addrs, port, attempt + 1, next_addr_idx, retry_after, max_attempts)
 
@@ -164,7 +166,7 @@ defmodule Paracusia.MpdClient do
 
         _ =
           Logger.warn(
-            "Connection refused for hostname #{ip_string(addr_family, hostname)}, " <>
+            "Connection refused for #{target_description}, " <>
               "trying #{ip_string(addr_family, next_hostname)} instead."
           )
 

--- a/lib/paracusia/mpd_client.ex
+++ b/lib/paracusia/mpd_client.ex
@@ -112,7 +112,7 @@ defmodule Paracusia.MpdClient do
   defp ip_addresses(hostname) do
     hostname = to_charlist(hostname)
 
-    if File.exists?(hostname) do
+    if socket?(hostname) do
       [{:local, hostname}]
     else
       ipv6 = {:inet6, :inet.getaddr(hostname, :inet6)}
@@ -124,6 +124,13 @@ defmodule Paracusia.MpdClient do
   defp ip_string(:inet, ip), do: :inet.ntoa(ip)
   defp ip_string(:inet6, ip), do: :inet.ntoa(ip)
   defp ip_string(:local, ip), do: ip
+
+  defp socket?(hostname) do
+    case File.stat(hostname) do
+      {:ok, %File.Stat{type: :other}} -> true
+      _ -> false
+    end
+  end
 
   defp connect_retry(addrs, port, attempt, addr_idx, retry_after, max_attempts) do
     if attempt > max_attempts do


### PR DESCRIPTION
Fixes #9 

If the hostname existed on the system as a directory or file, it would assumed to be a socket. This upgrades the logic to use `File.stat/1` to check the node type. When it's `:other`, it's a socket.

Also add some extra connection details to debug message to help diagnose failed connections.

(There weren't unit tests for this class, so I tested it the old fashioned way: by hand)